### PR TITLE
refactor: make domain object plain 'object's

### DIFF
--- a/src/api/mock/population.ts
+++ b/src/api/mock/population.ts
@@ -13,10 +13,11 @@ export class MockPopulationChangeAPI implements PopulationChangeAPI {
   }
 
   private generateMockPopulationChange(pref: Prefecture): PopulationChange {
-    const changes = Array.from({ length: 30 }).map(
-      (_, i) => new Population(2000 + i * 5, 100000 * i)
-    );
+    const changes = Array.from({ length: 30 }).map((_, i) => ({
+      year: 2000 + i * 5,
+      population: 100000 * i,
+    }));
 
-    return new PopulationChange(pref, 2020, changes);
+    return { pref, forecastBoundary: 2020, changes };
   }
 }

--- a/src/api/mock/pref.ts
+++ b/src/api/mock/pref.ts
@@ -6,8 +6,9 @@ export class MockPrefectureAPI implements PrefectureAPI {
   async fetchPrefectures(): Promise<Prefecture[]> {
     await delay(500);
 
-    return Array.from({ length: 50 }).map(
-      (_, i) => new Prefecture(`pref-${i}`, `Pref. #${i}`)
-    );
+    return Array.from({ length: 50 }).map((_, i) => ({
+      id: `pref-${i}`,
+      name: `Pref. #${i}`,
+    }));
   }
 }

--- a/src/domain/__test__/populationHistory.spec.ts
+++ b/src/domain/__test__/populationHistory.spec.ts
@@ -1,42 +1,33 @@
-import { Population, PopulationChange } from "../polulationChange";
+import {
+  getActualMeasuredChanges,
+  getSortedPopulationChange,
+  Population,
+  PopulationChange,
+} from "../polulationChange";
 import { Prefecture } from "../prefecture";
 
-const mockedPrefecture = new Prefecture("000", "Any Pref.");
-const mockedPopulation = [
-  new Population(2000, 100000),
-  new Population(2005, 200000),
-  new Population(2010, 300000),
-  new Population(2015, 400000),
-  new Population(2020, 500000),
+const mockedPrefecture: Prefecture = {
+  id: "000",
+  name: "Hoge",
+};
+const mockedPopulation: Array<Population> = [
+  { year: 2000, population: 100000 },
+  { year: 2005, population: 200000 },
+  { year: 2010, population: 300000 },
+  { year: 2015, population: 400000 },
+  { year: 2020, population: 500000 },
 ];
+const mockedPopulationChange: PopulationChange = {
+  pref: mockedPrefecture,
+  changes: mockedPopulation,
+  forecastBoundary: 2010,
+};
 
 describe("Population change object", () => {
-  test("forecast boundary must be included in the list", () => {
-    expect(
-      () => new PopulationChange(mockedPrefecture, 2000, mockedPopulation)
-    ).not.toThrowError();
-    expect(
-      () => new PopulationChange(mockedPrefecture, 2001, mockedPopulation)
-    ).toThrowError();
-  });
-
-  test("sorted actual or forecast changes can be get", () => {
-    const populationChange = new PopulationChange(
-      mockedPrefecture,
-      2010,
-      mockedPopulation
-    );
-
-    const actual = populationChange.getSortedActualChanges();
-    const forecast = populationChange.getSortedForecastChanges();
-    const all = populationChange.getSortedChanges();
+  test("sorted actual changes can be get", () => {
+    const actual = getActualMeasuredChanges(mockedPopulationChange);
 
     expect(actual.length).toBe(3);
     expect(actual[2].year).toBe(2010);
-
-    expect(forecast.length).toBe(2);
-    expect(forecast[0].year).toBe(2015);
-
-    expect(all.length).toBe(5);
   });
 });

--- a/src/domain/__test__/populationHistory.spec.ts
+++ b/src/domain/__test__/populationHistory.spec.ts
@@ -4,22 +4,16 @@ import {
   Population,
   PopulationChange,
 } from "../polulationChange";
-import { Prefecture } from "../prefecture";
 
-const mockedPrefecture: Prefecture = {
-  id: "000",
-  name: "Hoge",
-};
-const mockedPopulation: Array<Population> = [
-  { year: 2000, population: 100000 },
-  { year: 2005, population: 200000 },
-  { year: 2010, population: 300000 },
-  { year: 2015, population: 400000 },
-  { year: 2020, population: 500000 },
-];
 const mockedPopulationChange: PopulationChange = {
-  pref: mockedPrefecture,
-  changes: mockedPopulation,
+  pref: { id: "000", name: "Hoge" },
+  changes: [
+    { year: 2000, population: 100000 },
+    { year: 2005, population: 200000 },
+    { year: 2010, population: 300000 },
+    { year: 2015, population: 400000 },
+    { year: 2020, population: 500000 },
+  ],
   forecastBoundary: 2010,
 };
 
@@ -34,13 +28,14 @@ const isSorted = (array: Array<Population>) => {
 };
 
 describe("Population change object", () => {
-  test("sorted actual changes can be get", () => {
+  test("Actual changes can be filtered out", () => {
     const actual = getActualMeasuredChanges(mockedPopulationChange);
 
     expect(actual.length).toBe(3);
     expect(actual[2].year).toBe(2010);
   });
-  test("All changes and actual changes can be sorted", () => {
+
+  test("All changes and actual changes can be sorted by the year", () => {
     const sortedAllChange = getSortedPopulationChange(mockedPopulationChange);
     const sortedActualChange = getActualMeasuredChanges(mockedPopulationChange);
 

--- a/src/domain/__test__/populationHistory.spec.ts
+++ b/src/domain/__test__/populationHistory.spec.ts
@@ -23,11 +23,28 @@ const mockedPopulationChange: PopulationChange = {
   forecastBoundary: 2010,
 };
 
+const isSorted = (array: Array<Population>) => {
+  for (let i = 1; i < array.length; i++) {
+    if (array[i].year - array[i - 1].year < 0) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 describe("Population change object", () => {
   test("sorted actual changes can be get", () => {
     const actual = getActualMeasuredChanges(mockedPopulationChange);
 
     expect(actual.length).toBe(3);
     expect(actual[2].year).toBe(2010);
+  });
+  test("All changes and actual changes can be sorted", () => {
+    const sortedAllChange = getSortedPopulationChange(mockedPopulationChange);
+    const sortedActualChange = getActualMeasuredChanges(mockedPopulationChange);
+
+    expect(isSorted(sortedAllChange)).toBe(true);
+    expect(isSorted(sortedActualChange)).toBe(true);
   });
 });

--- a/src/domain/polulationChange.ts
+++ b/src/domain/polulationChange.ts
@@ -2,52 +2,32 @@ import { Prefecture } from "./prefecture";
 
 export type Year = number;
 
-export class Population {
-  readonly year: Year;
-  readonly population: number;
-
-  constructor(year: Year, population: number) {
-    this.year = year;
-    this.population = population;
-  }
+export interface Population {
+  year: Year;
+  population: number;
 }
 
-export class PopulationChange {
-  readonly pref: Prefecture;
-  readonly forecastBoundary: Year;
-
-  private readonly changes: Array<Population>;
+export interface PopulationChange {
+  pref: Prefecture;
+  changes: Array<Population>;
 
   /**
-   * @param forecastBoundary The boundary where the population switches from actual measured datas to forecast data.
-   *        The data which the year is {forecastBoundary} must be actual measured data.
-   * @param changes The list of the annual prefecture. The list will be cloned and sorted internally, and does not have to be sorted.
+   * The boundary where the population switches from actual measured datas to forecast data.
+   * The data which the year is {forecastBoundary} must be actual measured data.
    */
-  constructor(
-    pref: Prefecture,
-    forecastBoundary: Year,
-    changes: Array<Population>
-  ) {
-    if (changes.find((c) => c.year === forecastBoundary) === undefined) {
-      throw new RangeError(
-        `Forecast boundary year ${forecastBoundary} is not included in the changes list`
-      );
-    }
-
-    this.pref = pref;
-    this.forecastBoundary = forecastBoundary;
-    this.changes = [...changes].sort((c) => c.year);
-  }
-
-  getSortedChanges() {
-    return this.changes;
-  }
-
-  getSortedActualChanges() {
-    return this.changes.filter((c) => c.year <= this.forecastBoundary);
-  }
-
-  getSortedForecastChanges() {
-    return this.changes.filter((c) => c.year > this.forecastBoundary);
-  }
+  forecastBoundary: Year;
 }
+
+export const getSortedPopulationChange = (
+  change: PopulationChange
+): Array<Population> => {
+  return change.changes.sort((c) => c.year);
+};
+
+export const getActualMeasuredChanges = (
+  change: PopulationChange
+): Array<Population> => {
+  return getSortedPopulationChange(change).filter(
+    (c) => c.year <= change.forecastBoundary
+  );
+};

--- a/src/domain/prefecture.ts
+++ b/src/domain/prefecture.ts
@@ -1,9 +1,4 @@
-export class Prefecture {
-  readonly id: string;
-  readonly name: string;
-
-  constructor(id: string, name: string) {
-    this.id = id;
-    this.name = name;
-  }
+export interface Prefecture {
+  id: string;
+  name: string;
 }


### PR DESCRIPTION
To use `getStaticProps` simply and remove unused logic, I decided to make the domain objects into the plain 'object's.